### PR TITLE
Upgrade Maven plugins and test dependencies to latest stable

### DIFF
--- a/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/IsOpenExtension.java
+++ b/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/IsOpenExtension.java
@@ -15,7 +15,7 @@
  */
 package app.packed.moduletests.isopen;
 
-import app.packed.component.SidehandleTargetKind;
+import app.packed.extension.SidehandleTargetKind;
 import app.packed.extension.Extension;
 import app.packed.extension.ExtensionHandle;
 

--- a/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/IsOpenSidebean.java
+++ b/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/IsOpenSidebean.java
@@ -15,8 +15,8 @@
  */
 package app.packed.moduletests.isopen;
 
-import app.packed.component.SidehandleBinding;
-import app.packed.component.SidehandleBinding.Kind;
+import app.packed.extension.SidehandleBinding;
+import app.packed.extension.SidehandleBinding.Kind;
 
 /**
  *

--- a/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/IsOpenSidebeanNotOpen.java
+++ b/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/IsOpenSidebeanNotOpen.java
@@ -15,8 +15,8 @@
  */
 package app.packed.moduletests.isopen;
 
-import app.packed.component.SidehandleBinding;
-import app.packed.component.SidehandleBinding.Kind;
+import app.packed.extension.SidehandleBinding;
+import app.packed.extension.SidehandleBinding.Kind;
 import app.packed.moduletests.notopen.NotOpenInvokerInterface;
 
 /**

--- a/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/NewApp.java
+++ b/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/isopen/NewApp.java
@@ -15,13 +15,13 @@
  */
 package app.packed.moduletests.isopen;
 
-import static app.packed.component.SidehandleBinding.Kind.FROM_CONTEXT;
+import static app.packed.extension.SidehandleBinding.Kind.FROM_CONTEXT;
 
 import app.packed.application.BootstrapApp;
 import app.packed.application.ManagedApplicationRuntime;
 import app.packed.bean.Bean;
-import app.packed.component.SidehandleBinding;
-import app.packed.component.SidehandleContext;
+import app.packed.extension.SidehandleBinding;
+import app.packed.extension.SidehandleContext;
 import app.packed.lifecycle.LifecycleKind;
 /**
  *

--- a/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/notopen/NotOpenExtension.java
+++ b/modules/packed-modulepath-tests/src/main/java/app/packed/moduletests/notopen/NotOpenExtension.java
@@ -15,7 +15,7 @@
  */
 package app.packed.moduletests.notopen;
 
-import app.packed.component.SidehandleTargetKind;
+import app.packed.extension.SidehandleTargetKind;
 import app.packed.extension.Extension;
 import app.packed.extension.ExtensionHandle;
 import app.packed.moduletests.isopen.IsOpenSidebean;

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -27,8 +27,8 @@
     <root.dir>${project.basedir}/..</root.dir>
     
     <!-- Test Dependencies Versions -->
-    <version.test.assertj>3.26.3</version.test.assertj>
-    <version.test.junit>6.0.2</version.test.junit>
+    <version.test.assertj>3.27.7</version.test.assertj>
+    <version.test.junit>6.1.1</version.test.junit>
     <version.test.jmh>1.37</version.test.jmh>
     <version.jspecify>1.0.0</version.jspecify>
     

--- a/pom.xml
+++ b/pom.xml
@@ -12,31 +12,31 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.plugin.clean>3.5.0</version.plugin.clean>
     <version.plugin.bundle>5.1.9</version.plugin.bundle>
-    <version.plugin.compiler>3.14.1</version.plugin.compiler>
+    <version.plugin.compiler>3.15.0</version.plugin.compiler>
     <version.plugin.install>3.1.4</version.plugin.install>
     <version.plugin.deploy>3.1.4</version.plugin.deploy>
     <version.plugin.staging>1.7.0</version.plugin.staging>
     <version.plugin.versions>2.20.1</version.plugin.versions>
     <version.plugin.javadoc>3.12.0</version.plugin.javadoc>
     <version.plugin.source>3.3.1</version.plugin.source>
-    <version.plugin.shade>3.6.1</version.plugin.shade>
+    <version.plugin.shade>3.6.2</version.plugin.shade>
     <version.plugin.gpg>3.2.7</version.plugin.gpg>
     <version.plugin.jxr>3.6.0</version.plugin.jxr>
-    <version.plugin.invoker>3.9.1</version.plugin.invoker>
+    <version.plugin.invoker>3.10.1</version.plugin.invoker>
     <version.plugin.buildhelper>3.6.0</version.plugin.buildhelper>
     <version.plugin.jar>3.5.0</version.plugin.jar>
     <version.plugin.site>4.0.0-M16</version.plugin.site>
     <version.plugin.exec>3.5.0</version.plugin.exec>
     <version.plugin.plugin>3.17.0</version.plugin.plugin>
     <version.plugin.release>3.1.1</version.plugin.release>
-    <version.plugin.resources>3.4.0</version.plugin.resources>
+    <version.plugin.resources>3.5.0</version.plugin.resources>
     <version.plugin.assembly>3.7.1</version.plugin.assembly>
     <version.plugin.dependency>3.8.1</version.plugin.dependency>
     <version.plugin.help>3.5.1</version.plugin.help>
-    <version.plugin.surefire>3.5.4</version.plugin.surefire>
+    <version.plugin.surefire>3.5.6</version.plugin.surefire>
     <version.plugin.pitest>1.18.4</version.plugin.pitest>
     <version.plugin.animal-sniffer>1.24</version.plugin.animal-sniffer>
-    <version.plugin.enforcer>3.6.2</version.plugin.enforcer>
+    <version.plugin.enforcer>3.6.3</version.plugin.enforcer>
     <version.plugin.jacoco>0.8.12</version.plugin.jacoco>
     <version.plugin.coveralls>4.3.0</version.plugin.coveralls>
     <version.plugin.checkstyle>3.6.0</version.plugin.checkstyle>


### PR DESCRIPTION
Bumps all actively-used Maven plugins and test dependencies to their latest stable releases — junit-bom 6.0.2→6.1.1, assertj-core 3.26.3→3.27.7, surefire 3.5.4→3.5.6, compiler 3.14.1→3.15.0, resources 3.4.0→3.5.0, shade 3.6.1→3.6.2, enforcer 3.6.2→3.6.3, and invoker 3.9.1→3.10.1. This supersedes the open dependabot PRs (#219–#225), going further than several of them which had gone stale (e.g. JUnit's targeted 6.0.3 and surefire's 3.5.5). It also fixes a pre-existing compile break in `packed-modulepath-tests` by repointing the `Sidehandle*` imports (`SidehandleBinding`, `SidehandleTargetKind`, `SidehandleContext`) from `app.packed.component` to `app.packed.extension`, where those types now live. The referenced types, nested `Kind` enum constants, and `installSidebeanIfAbsent` signature are otherwise unchanged. Full reactor `mvn clean package` is green — all modules build and all tests pass.